### PR TITLE
Small improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /*.svg
+result*

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737469691,
-        "narHash": "sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk=",
+        "lastModified": 1750365781,
+        "narHash": "sha256-XE/lFNhz5lsriMm/yjXkvSZz5DfvKJLUjsS6pP8EC50=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab",
+        "rev": "08f22084e6085d19bcfb4be30d1ca76ecb96fe54",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
         tools = with pkgs; [
           tmux
           charm-freeze
-          fish
+          fishMinimal
           fontconfig
           nerd-fonts.jetbrains-mono
         ];
@@ -42,7 +42,7 @@
           terminal = pkgs.writeShellApplication {
             name = "terminal";
             runtimeInputs = with pkgs; [
-              fish
+              fishMinimal
               tmux
             ];
             text = ''

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,29 @@
             '';
           };
         };
+        packages = {
+          terminal = pkgs.writeShellApplication {
+            name = "terminal";
+            runtimeInputs = with pkgs; [
+              fish
+              tmux
+            ];
+            text = ''
+              tmux new-session 'fish --init-command="function fish_prompt; echo '"'"'\$'" '"'; end"'
+            '';
+          };
+          # Takes screenshots of the terminal instance
+          # usage: capture -o output.svg
+          # TODO: make excluded prompt lines configurable here
+          capture = pkgs.writeShellApplication {
+            name = "capture";
+            runtimeInputs = tools;
+            runtimeEnv.FONTCONFIG_PATH = "${pkgs.fontconfig}/etc/fonts";
+            text = ''
+              tmux capture-pane -pet 0 | freeze -c ${self}/freeze.json "$@"
+            '';
+          };
+        };
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -4,8 +4,14 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs {
           inherit system;

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,6 @@
           tmux
           charm-freeze
           fish
-          inkscape
           fontconfig
           nerd-fonts.jetbrains-mono
         ];
@@ -29,7 +28,7 @@
       {
         devShells = {
           default = pkgs.mkShell {
-            packages = tools;
+            packages = tools ++ [ pkgs.inkscape ];
             FONTCONFIG_PATH = "${pkgs.fontconfig.out}/etc/fonts";
           };
           start = pkgs.mkShell {


### PR DESCRIPTION
I've aimed to reduce the closure sizes a bit (which can be tested using [nix-tree](https://search.nixos.org/packages?channel=unstable&show=nix-tree&from=0&size=50&sort=relevance&type=packages&query=nix-tree)). This makes the commands faster to run (since the derivation builds faster), but also improves the user experience since you have less things to download in order to try the project.

1. Build derivations:

   ```shellSession
   $ nix build .#devShells.x86_64-linux.default -o result-devshell-default
   $ nix build .#devShells.x86_64-linux.start -o result-devshell-start
   $ nix build .#terminal -o result-terminal
   $ nix build .#capture -o result-capture
   ```

1. Measure the closure sizes:

   ```shellSession
   $ nix-tree ./result-devshell-default -> 1.72 GB
   $ nix-tree ./result-devshell-start -> 900 MiB
   $ nix-tree ./result-terminal -> 350 MiB
   $ nix-tree ./result-capture -> 590 MiB
   ```

Using `fishMinimal`, I was  able to reduce this even further:

```shellSession
$ nix-tree ./result-terminal -> 240 MiB
$ nix-tree ./result-capture -> 485 MiB
```

But I had to update the flake, since it was introduced at a later date than the current nixpkgs version.

Another change I did was using packages instead of devshells, which is a better workflow IMO. For example:

- Start the model terminal:

  ```shellSession
  nix run .#terminal
  ```

- Take a snapshot of the terminal:

  ```shellSession
  nix run .#capture -- -o capture.svg
  ```